### PR TITLE
[codex] Add reviewed June model releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ Models intentionally excluded from tracking despite high download counts:
 
 ## Changelog
 
+### 2026-06-15
+- Weekly Hugging Face sync
+- Added 1 models to `models.csv`: XiaomiMiMo
+- 26 candidates rejected, 11 left for manual review
+
 ### 2026-06-08
 - Weekly Hugging Face sync
 - Added 18 models to `models.csv`: google, nvidia

--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ Models intentionally excluded from tracking despite high download counts:
 
 ### 2026-06-15
 - Weekly Hugging Face sync
-- Added 1 models to `models.csv`: XiaomiMiMo
-- 26 candidates rejected, 11 left for manual review
+- Added 5 models to `models.csv`: google, MiniMaxAI, moonshotai, XiaomiMiMo
+- Added 2 models to `extra_models.csv`: CohereLabs
+- 26 candidates rejected, 5 left for manual review
 
 ### 2026-06-08
 - Weekly Hugging Face sync

--- a/extra_models.csv
+++ b/extra_models.csv
@@ -51,6 +51,8 @@ CohereLabs,command-a-plus-05-2026-bf16,CohereLabs/command-a-plus-05-2026-bf16
 CohereLabs,command-a-plus-05-2026-fp8,CohereLabs/command-a-plus-05-2026-fp8
 CohereLabs,command-a-plus-05-2026-w4a4,CohereLabs/command-a-plus-05-2026-w4a4
 CohereLabs,command-a-vision-07-2025,CohereLabs/command-a-vision-07-2025
+CohereLabs,North-Mini-Code-1.0,CohereLabs/North-Mini-Code-1.0
+CohereLabs,North-Mini-Code-1.0-fp8,CohereLabs/North-Mini-Code-1.0-fp8
 CohereLabs,tiny-aya-base,CohereLabs/tiny-aya-base
 CohereLabs,tiny-aya-earth,CohereLabs/tiny-aya-earth
 CohereLabs,tiny-aya-fire,CohereLabs/tiny-aya-fire

--- a/models.csv
+++ b/models.csv
@@ -310,6 +310,7 @@ google,codegemma-7b,google/codegemma-7b
 google,codegemma-7b-it,google/codegemma-7b-it
 google,codegemma-7b-it-pytorch,google/codegemma-7b-it-pytorch
 google,codegemma-7b-pytorch,google/codegemma-7b-pytorch
+google,diffusiongemma-26B-A4B-it,google/diffusiongemma-26B-A4B-it
 google,gemma-1.1-2b-it,google/gemma-1.1-2b-it
 google,gemma-1.1-2b-it-pytorch,google/gemma-1.1-2b-it-pytorch
 google,gemma-1.1-2b-it-tflite,google/gemma-1.1-2b-it-tflite
@@ -816,6 +817,8 @@ MiniMaxAI,MiniMax-M2,MiniMaxAI/MiniMax-M2
 MiniMaxAI,MiniMax-M2.1,MiniMaxAI/MiniMax-M2.1
 MiniMaxAI,MiniMax-M2.5,MiniMaxAI/MiniMax-M2.5
 MiniMaxAI,MiniMax-M2.7,MiniMaxAI/MiniMax-M2.7
+MiniMaxAI,MiniMax-M3,MiniMaxAI/MiniMax-M3
+MiniMaxAI,MiniMax-M3-MXFP8,MiniMaxAI/MiniMax-M3-MXFP8
 MiniMaxAI,MiniMax-Text-01,MiniMaxAI/MiniMax-Text-01
 MiniMaxAI,MiniMax-Text-01-hf,MiniMaxAI/MiniMax-Text-01-hf
 MiniMaxAI,MiniMax-VL-01,MiniMaxAI/MiniMax-VL-01
@@ -891,6 +894,7 @@ moonshotai,Kimi-K2-Instruct-0905,moonshotai/Kimi-K2-Instruct-0905
 moonshotai,Kimi-K2-Thinking,moonshotai/Kimi-K2-Thinking
 moonshotai,Kimi-K2.5,moonshotai/Kimi-K2.5
 moonshotai,Kimi-K2.6,moonshotai/Kimi-K2.6
+moonshotai,Kimi-K2.7-Code,moonshotai/Kimi-K2.7-Code
 moonshotai,Kimi-Linear-48B-A3B-Base,moonshotai/Kimi-Linear-48B-A3B-Base
 moonshotai,Kimi-Linear-48B-A3B-Instruct,moonshotai/Kimi-Linear-48B-A3B-Instruct
 moonshotai,Kimi-VL-A3B-Instruct,moonshotai/Kimi-VL-A3B-Instruct

--- a/models.csv
+++ b/models.csv
@@ -1590,6 +1590,7 @@ XiaomiMiMo,MiMo-V2-Flash,XiaomiMiMo/MiMo-V2-Flash
 XiaomiMiMo,MiMo-V2-Flash-Base,XiaomiMiMo/MiMo-V2-Flash-Base
 XiaomiMiMo,MiMo-V2.5-Pro,XiaomiMiMo/MiMo-V2.5-Pro
 XiaomiMiMo,MiMo-V2.5-Pro-Base,XiaomiMiMo/MiMo-V2.5-Pro-Base
+XiaomiMiMo,MiMo-V2.5-Pro-FP4-DFlash,XiaomiMiMo/MiMo-V2.5-Pro-FP4-DFlash
 XiaomiMiMo,MiMo-VL-7B-RL,XiaomiMiMo/MiMo-VL-7B-RL
 XiaomiMiMo,MiMo-VL-7B-RL-2508,XiaomiMiMo/MiMo-VL-7B-RL-2508
 XiaomiMiMo,MiMo-VL-7B-SFT,XiaomiMiMo/MiMo-VL-7B-SFT

--- a/policy/model_policy.yml
+++ b/policy/model_policy.yml
@@ -130,6 +130,7 @@ orgs:
   MiniMaxAI:
     primary_family_patterns:
       - "^MiniMax-M2\\.7(?:$|[-_])"
+      - "^MiniMax-M3(?:$|[-_])"
 
   mistralai:
     primary_family_patterns:
@@ -138,6 +139,7 @@ orgs:
   moonshotai:
     primary_family_patterns:
       - "^Kimi-K2\\.6(?:$|[-_])"
+      - "^Kimi-K2\\.7(?:$|[-_])"
 
   Qwen:
     primary_family_patterns:


### PR DESCRIPTION
## Summary

Extends #16 with the manually reviewed June 15 model candidates.

- Add `CohereLabs/North-Mini-Code-1.0` and its FP8 variant to `extra_models.csv`.
- Add `MiniMaxAI/MiniMax-M3`, its MXFP8 variant, `moonshotai/Kimi-K2.7-Code`, and `google/diffusiongemma-26B-A4B-it` to `models.csv`.
- Add MiniMax M3 and Kimi K2.7 family patterns so future matching releases are accepted automatically.
- Update the June 15 changelog totals from 11 manual-review candidates to 5.

## Impact

The reviewed releases are tracked in their existing primary/secondary catalog locations, and future MiniMax M3 and Kimi K2.7 variants no longer require manual classification.

## Validation

- `git diff --check`
- CSV header, model ID, duplicate, and sort-order validation for both catalogs
- `uv run sync_hf_models.py --dry-run --since-days 14 --verbose`
- Focused classifier check for MiniMax M3, MiniMax M3 MXFP8, and Kimi K2.7 Code
