### PR TITLE
Use unique branches for model sync PRs

### DIFF
--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -56,7 +56,7 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          branch: bot/sync-hf-models
+          branch: bot/sync-hf-models-${{ github.run_id }}
           delete-branch: true
           commit-message: Update tracked Hugging Face models
           title: Update tracked Hugging Face models


### PR DESCRIPTION
## What changed

Use `bot/sync-hf-models-${{ github.run_id }}` as the pull-request branch for each model-sync workflow run.

## Root cause

The workflow previously used the fixed `bot/sync-hf-models` branch. `peter-evans/create-pull-request` updates an existing pull request when that branch is reused, so the July 6 run force-replaced the still-open June 29 PR and its report.

## Behavior after this change

- Each new scheduled or manually dispatched workflow run gets a distinct branch and PR.
- Re-running the same workflow run keeps the same `github.run_id`, so retries update that run's PR instead of producing duplicates.
- The existing change detector still skips PR creation when there are no CSV or README changes.

## Validation

- Workflow YAML parsed successfully.
- The branch expression was checked exactly.
- `git diff --check` passed.

## Operational note

Because later runs no longer revisit old branch names, `delete-branch: true` will not clean these branches after merge. Repository-level automatic head-branch deletion should remain enabled or be enabled separately.

