### PR TITLE
Correct DeepSeek V4 release dates to 2026-04-24

### DIFF
--- a/metadata/release_date_corrections.csv
+++ b/metadata/release_date_corrections.csv
@@ -13,3 +13,7 @@ google/gemma-4-E2B-it,2026-03-02,2026-04-02,official Gemma 4 launch date from Go
 google/gemma-4-E4B-it,2026-03-02,2026-04-02,official Gemma 4 launch date from Google Keyword post
 google/gemma-4-31B-it,2026-03-11,2026-04-02,official Gemma 4 launch date from Google Keyword post
 google/gemma-4-26B-A4B-it,2026-03-11,2026-04-02,official Gemma 4 launch date from Google Keyword post
+deepseek-ai/DeepSeek-V4-Flash,2026-04-22,2026-04-24,2 days early
+deepseek-ai/DeepSeek-V4-Flash-Base,2026-04-22,2026-04-24,2 days early
+deepseek-ai/DeepSeek-V4-Pro,2026-04-22,2026-04-24,2 days early
+deepseek-ai/DeepSeek-V4-Pro-Base,2026-04-22,2026-04-24,2 days early


### PR DESCRIPTION
HF `created_at` for the four launch-day DeepSeek V4 repos (Flash, Flash-Base, Pro, Pro-Base) is 2026-04-22, but DeepSeek's official announcement dates the release **2026/04/24** ([news260424](https://api-docs.deepseek.com/news/news260424)) — the repos went up two days early. The June DSpark variants are separate releases and not corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)