### PR TITLE
Add 14 release date corrections from atom timeline audit

### DIFF
--- a/metadata/release_date_corrections.csv
+++ b/metadata/release_date_corrections.csv
@@ -17,3 +17,17 @@ deepseek-ai/DeepSeek-V4-Flash,2026-04-22,2026-04-24,2 days early
 deepseek-ai/DeepSeek-V4-Flash-Base,2026-04-22,2026-04-24,2 days early
 deepseek-ai/DeepSeek-V4-Pro,2026-04-22,2026-04-24,2 days early
 deepseek-ai/DeepSeek-V4-Pro-Base,2026-04-22,2026-04-24,2 days early
+Qwen/QwQ-32B-Preview,2024-11-27,2024-11-28,1 day early
+deepseek-ai/DeepSeek-V3,2024-12-25,2024-12-26,1 day early
+google/gemma-3-27b-it,2025-03-01,2025-03-12,11 days early; official Gemma 3 launch per Google blog
+deepseek-ai/DeepSeek-V3-0324,2025-03-24,2025-03-25,1 day early
+Qwen/Qwen3-235B-A22B-Instruct-2507,2025-07-21,2025-07-25,4 days early
+zai-org/GLM-4.5,2025-07-20,2025-07-28,8 days early; official Z.ai launch announcement
+stepfun-ai/step3,2025-07-28,2025-07-31,3 days early
+Qwen/Qwen3-Omni-30B-A3B-Instruct,2025-09-20,2025-09-22,2 days early; Qwen launch post Sep 22
+Qwen/Qwen3-VL-235B-A22B-Instruct,2025-09-22,2025-09-23,1 day early
+inclusionAI/Ling-1T,2025-10-02,2025-10-09,7 days early; Ant Group launch announcement
+MiniMaxAI/MiniMax-M2,2025-10-22,2025-10-27,5 days early; MiniMax launch post
+allenai/Olmo-3-32B-Think,2025-11-19,2025-11-20,1 day early
+mistralai/Mistral-Large-3-675B-Instruct-2512,2025-11-28,2025-12-02,4 days early; Mistral 3 launch Dec 2
+zai-org/GLM-5,2026-02-11,2026-02-12,1 day early


### PR DESCRIPTION
## What

14 new rows in `metadata/release_date_corrections.csv` where the HF `created_at` precedes the official public launch, found by auditing the atom open-model timeline against artifacts-models release dates. Contested dates were verified against official launch announcements:

- **Qwen3-Omni** → 2025-09-22 (official Qwen launch post; note the atom timeline itself says Sep 15 — fix incoming there)
- **Ling-1T** → 2025-10-09 (Ant Group announcement)
- **MiniMax-M2** → 2025-10-27 (MiniMax launch post)
- **Gemma 3** → 2025-03-12 (Google blog), **GLM-4.5** → 2025-07-28 (Z.ai announcement), **Mistral Large 3** → 2025-12-02 (Mistral 3 launch)
- plus 1–4 day `created_at` skews for QwQ-32B-Preview, DeepSeek-V3, DeepSeek-V3-0324, Qwen3-235B-A22B-Instruct-2507, step3, Qwen3-VL, Olmo-3-32B-Think, and GLM-5.

Rows already present (Kimi-K2-Thinking, Kimi-K2.5, gpt-oss-20b/120b, MiniMax-M2.1) were left untouched.

## Companions

- Interconnects-AI/artifacts-models#17 applies the same dates to the artifacts frontmatter.
- projectvail/artifacts-hub#51 adds the four timeline models that were missing from the hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)